### PR TITLE
Update the inherited class

### DIFF
--- a/src/provider.ts
+++ b/src/provider.ts
@@ -12,7 +12,7 @@ import {
 } from "vscode";
 
 const LINE_PATTERN = / render (?:[a-zA-Z:]+)?$/;
-const NAME_PATTERN = /class (.*?) < ViewComponent::Base/m;
+const NAME_PATTERN = /class (.*?) < .*Component.*/;
 const ARGS_PATTERN = /def initialize\(([^)]+)\)?/m;
 const COMPONENT_GLOB = 'app/components/**/*_component.rb';
 


### PR DESCRIPTION
Hi,

Thanks for the extension. 

I would like to contribute to it if you accept.

All components is not necessary to inherit from ViewComponent::Base. So, the inherited class can be more generic.For example;

```
class ApplicationComponent < ViewComponent::Base
  def a_useful_method_for_components
    ...
  end
end

class Users::UserComponent < ApplicationComponent
end
```